### PR TITLE
fix: add NULL safety for vector and matrix utils

### DIFF
--- a/cla/CMakeLists.txt
+++ b/cla/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 
 # Setting project name, version and language
 project(cla
-        VERSION 0.2
+        VERSION 0.2.1
         LANGUAGES CUDA C)
 
 # Find CUDAToolkit

--- a/cla/matrix/utils.c
+++ b/cla/matrix/utils.c
@@ -45,6 +45,9 @@ Matrix *const_matrix(int rows, int columns, double value, CUDADevice *device) {
 }
 
 void destroy_matrix(Matrix *matrix) {
+  // Precondition
+  assert(matrix != NULL);
+
   if (matrix->device != NULL) {
     matrix_to_cpu(matrix);
   }
@@ -57,13 +60,17 @@ void destroy_matrix(Matrix *matrix) {
 }
 
 Matrix *copy_matrix(Matrix *a, Matrix *dst) {
-  // Precondition
-  assert(matrix_has_same_dims_same_devices(a, dst, a));
+  // Precondition A
+  assert(a != NULL);
 
+  // Maybe allocate dst
   CUDADevice *device = a->device;
   int rows = a->rows;
   int columns = a->columns;
   dst = maybe_alloc_matrix(dst, rows, columns, device);
+
+  // Precondition B
+  assert(matrix_has_same_dims_same_devices(a, dst, a));
 
   if (device != NULL) {
     matrix_to_cpu(a);
@@ -85,6 +92,9 @@ Matrix *copy_matrix(Matrix *a, Matrix *dst) {
 }
 
 void print_matrix(Matrix *a, char *suffix) {
+  // Precondition
+  assert(a != NULL);
+
   int i, j;
   CUDADevice *device = a->device;
   matrix_to_cpu(a);
@@ -107,6 +117,9 @@ void print_matrix(Matrix *a, char *suffix) {
 }
 
 Matrix *matrix_from_vector(Vector *a, Vector2MatrixStrategy strategy) {
+  // Precondition
+  assert(a != NULL);
+
   int rows = 1, columns = a->dims;
   if (strategy == Vector2MatrixStrategy_COLUMN) {
     rows = a->dims;
@@ -140,16 +153,20 @@ Matrix *matrix_from_vector(Vector *a, Vector2MatrixStrategy strategy) {
 }
 
 bool matrix_has_same_dims_same_devices(Matrix *a, Matrix *b, Matrix *dst) {
+  assert(a != NULL && b != NULL && dst != NULL);
   return a->device == b->device && b->device == dst->device &&
          a->rows == b->rows && a->columns == b->columns &&
          b->rows == dst->rows && b->columns == dst->columns;
 }
 
 bool matrix_is_mult_compat(Matrix *a, Matrix *b, Matrix *dst) {
-  // Checking whether multiplication is possible
+  assert(a != NULL && b != NULL && dst != NULL);
   return a->device == b->device && b->device == dst->device &&
          a->columns == b->rows && dst->rows == a->rows &&
          dst->columns == b->columns;
 }
 
-bool matrix_is_square(Matrix *a) { return a->rows == a->columns; }
+bool matrix_is_square(Matrix *a) {
+  assert(a != NULL);
+  return a->rows == a->columns;
+}

--- a/cla/vector/utils.c
+++ b/cla/vector/utils.c
@@ -60,6 +60,9 @@ Vector *create_vector(int dims, CUDADevice *device, ...) {
 }
 
 void destroy_vector(Vector *vector) {
+  // Precondition
+  assert(vector != NULL);
+
   if (vector->device != NULL) {
     vector_to_cpu(vector);
   }
@@ -69,23 +72,23 @@ void destroy_vector(Vector *vector) {
 }
 
 Vector *copy_vector(Vector *a, Vector *dst) {
-  // Precondition
-  assert(vector_has_same_dims_same_devices(a, dst, a));
+  // Preconditions A
+  assert(a != NULL);
 
+  // Maybe allocate dst
   CUDADevice *device = a->device;
   dst = maybe_alloc_vector(dst, a->dims, device);
+
+  // Precondition V
+  assert(vector_has_same_dims_same_devices(a, dst, a));
 
   if (device != NULL) {
     vector_to_cpu(a);
     vector_to_cpu(dst);
   }
 
-  dst->dims = a->dims;
-  dst->device = a->device;
-  dst->arr = (double *)malloc(dst->dims * sizeof(double));
   for (int i = 0; i < dst->dims; i++) {
-    double *ptr = dst->arr + i;
-    *ptr = a->arr[i];
+    dst->arr[i] = a->arr[i];
   }
 
   if (device != NULL) {
@@ -97,6 +100,9 @@ Vector *copy_vector(Vector *a, Vector *dst) {
 }
 
 void print_vector(Vector *a, char *suffix) {
+  // Precondition
+  assert(a != NULL);
+
   CUDADevice *device = a->device;
   if (device != NULL) {
     vector_to_cpu(a);
@@ -119,6 +125,7 @@ void print_vector(Vector *a, char *suffix) {
 }
 
 bool vector_has_same_dims_same_devices(Vector *a, Vector *b, Vector *dst) {
+  assert(a != NULL && b != NULL && dst != NULL);
   return a->device == b->device && b->device == dst->device &&
          a->dims == b->dims && b->dims == dst->dims;
 }


### PR DESCRIPTION
- Add new test for vector copy;
- Update utilities with NULL safety (i.e., asserts pointers are non-null);
- Update patch version in cla/CMakeLists.txt;