### PR TITLE
fix: add device sync after kernel launch

### DIFF
--- a/cla/CMakeLists.txt
+++ b/cla/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 
 # Setting project name, version and language
 project(cla
-        VERSION 1.1.0
+        VERSION 1.1.1
         LANGUAGES CUDA C)
 
 # Find CUDAToolkit

--- a/cla/cuda/utils.cu
+++ b/cla/cuda/utils.cu
@@ -183,6 +183,9 @@ extern "C" Vector *cpu_gpu_conditional_apply_vector_operator(
     // Launch the kernel with the cu_vectors
     gpu_op<<<params.n_blocks, params.n_threads>>>(a->cu_vector, b->cu_vector,
                                                   dst->cu_vector);
+
+    // Synchronize CUDA devices
+    cudaDeviceSynchronize();
   }
 
   // Return dst
@@ -212,6 +215,9 @@ Vector *cpu_gpu_conditional_apply_scalar_vector_operator(
     // Launch the kernel with the cu_vectors
     gpu_op<<<params.n_blocks, params.n_threads>>>(cu_a, b->cu_vector,
                                                   dst->cu_vector);
+
+    // Synchronize CUDA devices
+    cudaDeviceSynchronize();
 
     // Deallocate memory
     cudaFree(cu_a);
@@ -243,6 +249,9 @@ extern "C" Matrix *cpu_gpu_conditional_apply_matrix_operator(
     // Launch the kernel with the cu_matrices
     gpu_op<<<params.n_blocks, params.n_threads>>>(a->cu_matrix, b->cu_matrix,
                                                   dst->cu_matrix);
+
+    // Synchronize CUDA devices
+    cudaDeviceSynchronize();
   }
 
   // Return dst
@@ -273,6 +282,9 @@ extern "C" Matrix *cpu_gpu_conditional_apply_scalar_matrix_operator(
     // Launch the kernel with the cu_matrices
     gpu_op<<<params.n_blocks, params.n_threads>>>(cu_a, b->cu_matrix,
                                                   dst->cu_matrix);
+
+    // Synchronize CUDA devices
+    cudaDeviceSynchronize();
 
     // Deallocate memory
     cudaFree(cu_a);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pycla"
-version = "1.1.0"
+version = "1.1.1"
 readme = "README.md"
 description = "CLA is a simple toy library for basic vector/matrix operations written C + CUDA with a Python API."
 requires-python = ">=3.13"


### PR DESCRIPTION
- Update cla to v1.1.1;
- Device synchronization is needed to avoid race conditions and time mismatch between CPU-GPU;
- See: https://stackoverflow.com/questions/11888772/when-to-call-cudadevicesynchronize